### PR TITLE
Error handling when trying to query a bad URL

### DIFF
--- a/app/src/main/java/com/example/android/routegradient/MainActivity.java
+++ b/app/src/main/java/com/example/android/routegradient/MainActivity.java
@@ -26,6 +26,7 @@ public class MainActivity extends AppCompatActivity {
     private EditText mRoute2EditText;
     private ProgressBar mLoadingProgressBar;
     private TextView mLoadingErrorMessage;
+    private TextView mBadResultErrorMessage;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -36,6 +37,7 @@ public class MainActivity extends AppCompatActivity {
         mRoute2EditText = (EditText)findViewById(R.id.et_route2_entry);
         mLoadingProgressBar = (ProgressBar)findViewById(R.id.pb_loading_indicator);
         mLoadingErrorMessage = (TextView)findViewById(R.id.tv_loading_error);
+        mBadResultErrorMessage = (TextView)findViewById(R.id.tv_bad_result_error);
 
         Button routeButton = (Button)findViewById(R.id.btn_find_route);
         routeButton.setOnClickListener(new View.OnClickListener() {
@@ -82,12 +84,18 @@ public class MainActivity extends AppCompatActivity {
         @Override
         protected void onPostExecute(String s) {
             mLoadingProgressBar.setVisibility(View.INVISIBLE);
+            mLoadingErrorMessage.setVisibility(View.INVISIBLE);
+            mBadResultErrorMessage.setVisibility(View.INVISIBLE);
             if (s != null) {
-                Log.d(TAG, "Route Utils API result: " + s);
-                String routeResult = RouteUtils.parseRouteJSON(s);
-                Log.d(TAG, "Route Utils parsed result: " + routeResult);
-                mLoadingErrorMessage.setVisibility(View.INVISIBLE);
-                doElevationSearch(routeResult);
+                if (RouteUtils.getStatusFromJSON(s).equals("OK")) {
+                    Log.d(TAG, "Route Utils API result: " + s);
+                    String routeResult = RouteUtils.parseRouteJSON(s);
+                    Log.d(TAG, "Route Utils parsed result: " + routeResult);
+                    doElevationSearch(routeResult);
+                }
+                else {
+                    mBadResultErrorMessage.setVisibility(View.VISIBLE);
+                }
             } else {
                 mLoadingErrorMessage.setVisibility(View.VISIBLE);
             }

--- a/app/src/main/java/com/example/android/routegradient/RouteUtils.java
+++ b/app/src/main/java/com/example/android/routegradient/RouteUtils.java
@@ -7,6 +7,9 @@ import com.google.gson.JsonParser;
 
 import com.example.android.routegradient.BuildConfig;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 /**
  * Created by cbenson on 3/17/18.
  */
@@ -25,6 +28,17 @@ public class RouteUtils {
                 .appendQueryParameter("key", BuildConfig.DIRECTIONS_KEY)
                 .build()
                 .toString();
+    }
+
+    public static String getStatusFromJSON(String routeJSON) {
+        String status = "";
+        try {
+            status = new JSONObject(routeJSON).getString("status");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
+        return status;
     }
 
     public static String parseRouteJSON(String routeJSON){

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,6 +34,15 @@
         android:layout_height="match_parent">
 
         <TextView
+            android:id="@+id/tv_bad_result_error"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="20sp"
+            android:padding="16dp"
+            android:text="@string/bad_result_error_message"
+            android:visibility="invisible"/>
+
+        <TextView
             android:id="@+id/tv_loading_error"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Route Gradient</string>
     <string name="action_settings">Settings</string>
     <string name="loading_error_message">Unable to execute search. Check your internet connection and try again.</string>
+    <string name="bad_result_error_message">Something went wrong. Make sure you have the right coordinates and try again.</string>
 
     <!--Preferences strings-->
     <string name="pref_units_key">pref_units</string>


### PR DESCRIPTION
Fixes a bug that caused the app to crash when given bad coordinates. If JSON results contain bad data, an error message is now displayed instead of trying to parse the bad data.